### PR TITLE
Change cursor to move

### DIFF
--- a/css/GalleryUploadField.css
+++ b/css/GalleryUploadField.css
@@ -77,7 +77,11 @@
 	background: #fff;
 	border: 1px solid #ccc;
 	margin: 10px;
-	cursor: pointer;
+	cursor: move;
+}
+.galleryupload .ss-uploadfield-files .ss-uploadfield-item label, 
+.galleryupload .ss-uploadfield-files .ss-uploadfield-item.ui-state-error label {
+	cursor: move;
 }
 
 .galleryupload .ss-uploadfield-files .ss-uploadfield-item:last-child,


### PR DESCRIPTION
This makes it obvious the items can be sorted. Good for usabililty.
'cursor: move;' also had to be put on the image label, as this is set to pointer in the CMS, and we don't want to cursor changing as a user moves over the label.
