### PR TITLE
FIX: Removed the loading spinner which didn't disappear and prevented editing images.

### DIFF
--- a/templates/GalleryUploadField.ss
+++ b/templates/GalleryUploadField.ss
@@ -87,7 +87,7 @@
 					</div>
 				</div>
 
-				<div class="ss-uploadfield-item-editform loading includeParent">
+				<div class="ss-uploadfield-item-editform includeParent">
 					<iframe frameborder="0" src="$UploadFieldEditLink"></iframe>
 				</div>
 


### PR DESCRIPTION
When the CMS page first loads, each uploaded image has a 'loading' class which doesn't get removed, meaning that the spinner remains over the image field.

This prevented the click event from being triggered on the edit button meaning images (ie caption) could not be edited.
