### PR TITLE
Don't Preload item Edit form

### DIFF
--- a/templates/GalleryUploadField.ss
+++ b/templates/GalleryUploadField.ss
@@ -88,7 +88,7 @@
 				</div>
 
 				<div class="ss-uploadfield-item-editform includeParent">
-					<iframe frameborder="0" src="$UploadFieldEditLink"></iframe>
+					<iframe frameborder="0" data-src="$UploadFieldEditLink" src="about:blank"></iframe>
 				</div>
 
 			</li>


### PR DESCRIPTION
SS now doesn't preload item edit forms this is the change needed to match current uploadfield JS bindings
