### PR TITLE
Make doEdit compatibile with extended Image class

### DIFF
--- a/code/GalleryUploadField.php
+++ b/code/GalleryUploadField.php
@@ -409,7 +409,10 @@ class GalleryUploadField_ItemHandler extends UploadField_ItemHandler {
 
 		$form->saveInto($joinObj);
 		$joinObj->write();
-
+		
+		$form->saveInto($item);
+		$item->write();
+		
 		$form->sessionMessage(_t('UploadField.Saved', 'Saved'), 'good');
 
 		return $this->edit($request);


### PR DESCRIPTION
Add a write operation for the $item as well to ensure that if the Image has an extension (like FocusPoint) changes are saved.
